### PR TITLE
Add Llama runner subprocess to GameDirector plugin

### DIFF
--- a/Plugins/GameDirectorPlugin/Source/GameDirectorPlugin/Private/GameDirectorPlugin.cpp
+++ b/Plugins/GameDirectorPlugin/Source/GameDirectorPlugin/Private/GameDirectorPlugin.cpp
@@ -1,20 +1,39 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
 #include "GameDirectorPlugin.h"
+#include "Misc/Paths.h"
+#include "HAL/PlatformProcess.h"
 
 #define LOCTEXT_NAMESPACE "FGameDirectorPluginModule"
 
 void FGameDirectorPluginModule::StartupModule()
 {
-	// This code will execute after your module is loaded into memory; the exact timing is specified in the .uplugin file per-module
+        // This code will execute after your module is loaded into memory; the exact timing is specified in the .uplugin file per-module
+        StartLlamaRunner();
 }
 
 void FGameDirectorPluginModule::ShutdownModule()
 {
-	// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
-	// we call this function before unloading the module.
+        // This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
+        // we call this function before unloading the module.
+        if (LlamaRunnerHandle.IsValid())
+        {
+                FPlatformProcess::TerminateProc(LlamaRunnerHandle, true);
+                LlamaRunnerHandle.Reset();
+        }
+}
+
+void FGameDirectorPluginModule::StartLlamaRunner()
+{
+        const FString RunnerPath = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), TEXT("Binaries/Win64/llama-runner.exe")));
+        LlamaRunnerHandle = FPlatformProcess::CreateProc(*RunnerPath, nullptr, true, false, false, nullptr, 0, nullptr, nullptr);
+
+        if (!LlamaRunnerHandle.IsValid())
+        {
+                UE_LOG(LogTemp, Warning, TEXT("Failed to start Llama runner process at %s"), *RunnerPath);
+        }
 }
 
 #undef LOCTEXT_NAMESPACE
-	
+
 IMPLEMENT_MODULE(FGameDirectorPluginModule, GameDirectorPlugin)

--- a/Plugins/GameDirectorPlugin/Source/GameDirectorPlugin/Public/GameDirectorPlugin.h
+++ b/Plugins/GameDirectorPlugin/Source/GameDirectorPlugin/Public/GameDirectorPlugin.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "Modules/ModuleManager.h"
+#include "HAL/PlatformProcess.h"
 
 class FGameDirectorPluginModule : public IModuleInterface
 {
@@ -10,5 +11,12 @@ public:
 
 	/** IModuleInterface implementation */
 	virtual void StartupModule() override;
-	virtual void ShutdownModule() override;
+        virtual void ShutdownModule() override;
+
+        /** Launches the external Llama runner process */
+        void StartLlamaRunner();
+
+private:
+        /** Handle to the spawned Llama runner process */
+        FProcHandle LlamaRunnerHandle;
 };


### PR DESCRIPTION
## Summary
- launch Llama runner subprocess when GameDirector plugin starts
- provide API and cleanup for spawned process

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b47835657c832eaa1e76b968e151b3