### PR TITLE
Add ULlamaRunner utility for Llama backend init

### DIFF
--- a/Plugins/GameDirectorPlugin/Source/GameDirectorPlugin/Private/GameDirectorPluginSubsystem.cpp
+++ b/Plugins/GameDirectorPlugin/Source/GameDirectorPlugin/Private/GameDirectorPluginSubsystem.cpp
@@ -2,9 +2,13 @@
 
 #include "GameDirectorPluginSubsystem.h"
 #include "Misc/Paths.h"
+#include "LlamaRunner.h"
 
 void UGameDirectorPluginSubsystem::InitiateLlamaRunner()
 {
+    // Ensure the Llama backend is initialised before attempting to launch any runner process
+    ULlamaRunner::InitiateLlama();
+
     if (LlamaRunnerHandle.IsValid())
     {
         return;

--- a/Plugins/GameDirectorPlugin/Source/GameDirectorPlugin/Private/LlamaRunner.cpp
+++ b/Plugins/GameDirectorPlugin/Source/GameDirectorPlugin/Private/LlamaRunner.cpp
@@ -1,0 +1,12 @@
+#include "LlamaRunner.h"
+
+#include "llama.h"
+
+void ULlamaRunner::InitiateLlama()
+{
+    // Initialize the llama backend; required before any other llama.cpp calls.
+    llama_backend_init();
+
+    UE_LOG(LogTemp, Log, TEXT("Llama backend initialized for build 58fc6cefe213c8af02153b994b738b3cb6ef2ba7"));
+}
+

--- a/Plugins/GameDirectorPlugin/Source/GameDirectorPlugin/Public/LlamaRunner.h
+++ b/Plugins/GameDirectorPlugin/Source/GameDirectorPlugin/Public/LlamaRunner.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "LlamaRunner.generated.h"
+
+/**
+ * Utility library for working with the bundled Llama build.
+ * Provides helpers for initializing the backend prior to use.
+ */
+UCLASS()
+class GAMEDIRECTORPLUGIN_API ULlamaRunner : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+
+public:
+    /**
+     * Initialises the Llama backend used by this plugin.
+     * The implementation targets build 58fc6cefe213c8af02153b994b738b3cb6ef2ba7.
+     */
+    UFUNCTION(BlueprintCallable, Category="Llama")
+    static void InitiateLlama();
+};
+


### PR DESCRIPTION
## Summary
- Create `ULlamaRunner` blueprint library exposing `InitiateLlama` for Llama build `58fc6cefe213c8af02153b994b738b3cb6ef2ba7`
- Use new `ULlamaRunner` from plugin subsystem before launching the runner process

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b47e158338832e982277650c80c5f8