### PR TITLE
Refactor Llama runner initialization

### DIFF
--- a/Plugins/GameDirectorPlugin/Source/GameDirectorPlugin/Private/GameDirectorPluginSubsystem.cpp
+++ b/Plugins/GameDirectorPlugin/Source/GameDirectorPlugin/Private/GameDirectorPluginSubsystem.cpp
@@ -2,29 +2,44 @@
 
 #include "GameDirectorPluginSubsystem.h"
 #include "Misc/Paths.h"
+#include "llama.h"
 
-void UGameDirectorPluginSubsystem::InitiateLlamaRunner()
+bool UGameDirectorPluginSubsystem::InitiateLlamaRunner()
 {
-    if (LlamaRunnerHandle.IsValid())
+    if (Runner.IsValid())
     {
-        return;
+        return true;
     }
 
-    const FString RunnerPath = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), TEXT("Binaries/Win64/llama-runner.exe")));
-    LlamaRunnerHandle = FPlatformProcess::CreateProc(*RunnerPath, nullptr, true, false, false, nullptr, 0, nullptr, nullptr);
+    Runner = MakeUnique<FLlamaRunner>();
 
-    if (!LlamaRunnerHandle.IsValid())
+    FLlamaParams P;
+
+    // Model + runtime settings
+    P.ModelPath = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), TEXT("Models"), TEXT("model.gguf")));
+    P.ContextLength = 2048;      // best for RTX 2060
+    P.MaxTokens = 512;           // cap per call, bump if needed
+    P.Temperature = 0.8f;
+    P.NumThreads = 0;            // auto-detect threads
+    P.bPreferGPU = true;
+    P.NGpuLayers = 12;           // sweet spot from CLI tests
+    P.GPUBatchSize = 2048;       // prompt ingestion speed
+
+    if (!Runner->Init(P))
     {
-        UE_LOG(LogTemp, Warning, TEXT("Failed to start Llama runner process at %s"), *RunnerPath);
+        Runner.Reset();
+        UE_LOG(LogTemp, Error, TEXT("Failed to load model"));
+        return false;
     }
+
+    return true;
 }
 
 void UGameDirectorPluginSubsystem::Deinitialize()
 {
-    if (LlamaRunnerHandle.IsValid())
+    if (Runner.IsValid())
     {
-        FPlatformProcess::TerminateProc(LlamaRunnerHandle, true);
-        LlamaRunnerHandle.Reset();
+        Runner.Reset();
     }
 }
 

--- a/Plugins/GameDirectorPlugin/Source/GameDirectorPlugin/Public/GameDirectorPluginSubsystem.h
+++ b/Plugins/GameDirectorPlugin/Source/GameDirectorPlugin/Public/GameDirectorPluginSubsystem.h
@@ -3,9 +3,12 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "HAL/PlatformProcess.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "GameDirectorPluginSubsystem.generated.h"
+
+// Forward declarations for Llama runner support
+struct FLlamaParams;
+class FLlamaRunner;
 
 UCLASS()
 class GAMEDIRECTORPLUGIN_API UGameDirectorPluginSubsystem : public UGameInstanceSubsystem
@@ -14,11 +17,12 @@ class GAMEDIRECTORPLUGIN_API UGameDirectorPluginSubsystem : public UGameInstance
 
 public:
     UFUNCTION(BlueprintCallable, Category="GameDirector")
-    void InitiateLlamaRunner();
+    bool InitiateLlamaRunner();
 
     virtual void Deinitialize() override;
 
 private:
-    FProcHandle LlamaRunnerHandle;
+    // In-process Llama runner instance
+    TUniquePtr<FLlamaRunner> Runner;
 };
 


### PR DESCRIPTION
## Summary
- Initialize Llama runner in-process with `FLlamaRunner` and `FLlamaParams`
- Store runner as `TUniquePtr` and clean up on subsystem deinit

## Testing
- `clang++ -std=c++17 Plugins/GameDirectorPlugin/Source/GameDirectorPlugin/Private/GameDirectorPluginSubsystem.cpp -IPlugins/GameDirectorPlugin/Source/GameDirectorPlugin/Public -IPlugins/GameDirectorPlugin/Source/ThirdParty/llama/include` *(fails: command not found: clang++)*

------
https://chatgpt.com/codex/tasks/task_e_68b47ebec468832ea27a5f3e9e6d8f19